### PR TITLE
Add bundler cache for Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,10 @@
 language: ruby
 rvm:
  - 2.4.1
+cache:
+  bundler: true
+  # Test Caching is good.
+  # See: https://docs.travis-ci.com/user/caching/
 services:
   - postgresql
 addons:


### PR DESCRIPTION
Goal:
- don't install the whole gemset each time the travis specs run

Changes:
- set bundler cache config to true

@davidneto92 